### PR TITLE
[WIP] Add CycleReward

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ from imscore.mps.model import MPS
 from imscore.preference.model import SiglipPreferenceScorer, CLIPScore
 from imscore.pickscore.model import PickScorer
 from imscore.imreward.model import ImageReward
+from imscore.cyclereward.model import CycleReward
 
 import torch
 import numpy as np
@@ -42,6 +43,7 @@ model = MPS.from_pretrained("RE-N-Y/mpsv1") # MPS (ovreall) preference scorer
 model = HPSv2.from_pretrained("RE-N-Y/hpsv21") # HPSv2.1 preference scorer
 model = ImageReward.from_pretrained("RE-N-Y/ImageReward") # ImageReward aesthetic scorer
 model = LAIONAestheticScorer.from_pretrained("RE-N-Y/laion-aesthetic") # LAION aesthetic scorer
+model = CycleReward.from_pretrained('NagaSaiAbhinay/CycleReward-Combo') # CycleReward preference scorer.
 
 # multimodal (pixels + text) preference scorers trained on PickaPicv2 dataset 
 model = SiglipPreferenceScorer.from_pretrained("RE-N-Y/pickscore-siglip")
@@ -117,11 +119,16 @@ from imscore.mps.model import MPS
 from imscore.imreward.model import ImageReward
 from imscore.preference.model import SiglipPreferenceScorer, CLIPPreferenceScorer
 from imscore.pickscore.model import PickScorer
+from imscore.cyclereward.model import CycleReward
 
 HPSv2.from_pretrained("RE-N-Y/hpsv21") # HPSv2.1 preference scorer
 MPS.from_pretrained("RE-N-Y/mpsv1") # MPS (ovreall) preference scorer
 PickScorer("yuvalkirstain/PickScore_v1") # PickScore preference scorer
 ImageReward.from_pretrained("RE-N-Y/ImageReward") # ImageReward preference scorer
+CycleReward.from_pretrained('NagaSaiAbhinay/CycleReward-Combo') #CycleReward preference scorer trained on combined CyclePrefDB
+CycleReward.from_pretrained('NagaSaiAbhinay/CycleReward-T2I')#CycleReward preference scorer trained on CyclePrefDB-T2I only
+CycleReward.from_pretrained('NagaSaiAbhinay/CycleReward-I2T')
+#CycleReward preference scorer trained on CyclePrefDB-I2T only
 
 # multimodal scorers trained on PickAPicv2 dataset
 SiglipPreferenceScorer.from_pretrained("RE-N-Y/pickscore-siglip")

--- a/src/imscore/cyclereward/model.py
+++ b/src/imscore/cyclereward/model.py
@@ -1,0 +1,67 @@
+
+import torch
+import torch.nn as nn
+import torchvision.transforms as T
+from torchvision.transforms import InterpolationMode
+from huggingface_hub import PyTorchModelHubMixin
+from ..imreward.model import BLIP
+
+class MLP(nn.Module):
+    def __init__(self, hiddens):
+        super().__init__()
+        self.hiddens = hiddens
+        self.layers = nn.Sequential(
+            nn.Linear(hiddens, 1024),
+            nn.GELU(),
+            nn.Linear(1024, 128),
+            nn.GELU(),
+            nn.Linear(128, 64),
+            nn.GELU(),
+            nn.Linear(64, 16),
+            nn.GELU(),
+            nn.Linear(16, 1)
+        )
+        
+    def forward(self, input):
+        return self.layers(input)
+
+
+class CycleReward(
+        nn.Module,
+        PyTorchModelHubMixin,
+        library_name="imscore",
+        repo_url="https://github.com/RE-N-Y/imscore"
+    ):
+
+    def __init__(self):
+        super().__init__()
+        
+        self.blip = BLIP(image_size=224)
+        self.preprocess = T.Compose([
+            T.Resize(224, interpolation=InterpolationMode.BICUBIC),
+            T.CenterCrop(224),
+            T.Normalize((0.48145466, 0.4578275, 0.40821073), (0.26862954, 0.26130258, 0.27577711)),
+        ])
+
+        self.mlp = MLP(768)
+    
+    def score(self, opixels, prompts:list[str]):
+        pixels = self.preprocess(opixels)
+        texts = self.blip.tokenizer(prompts, padding='max_length', truncation=True, max_length=128, return_tensors="pt")
+        embeds = self.blip.visual_encoder(pixels)
+
+        b, t, d = embeds.shape
+        mask = torch.ones(b, t, device=embeds.device, dtype=torch.bool)
+        texts = texts.to(embeds.device)
+        
+        text_output = self.blip.text_encoder(
+            texts.input_ids,
+            attention_mask = texts.attention_mask,
+            encoder_hidden_states = embeds,
+            encoder_attention_mask = mask,
+        )
+
+        txt_features = text_output[:,0,:]
+        rewards = self.mlp(txt_features)
+        
+        return rewards

--- a/test/test.py
+++ b/test/test.py
@@ -5,6 +5,7 @@ from imscore.preference.model import SiglipPreferenceScorer, CLIPPreferenceScore
 from imscore.pickscore.model import PickScorer
 from imscore.imreward.model import ImageReward
 from imscore.vqascore.model import VQAScore
+from imscore.cyclereward.model import CycleReward
 import torch
 import numpy as np
 from PIL import Image
@@ -40,6 +41,8 @@ def factory(name:str):
             return ImageReward.from_pretrained("RE-N-Y/ImageReward")
         case "VQAScore":
             return VQAScore.from_pretrained("RE-N-Y/clip-t5-xxl")
+        case "CycleReward":
+            return CycleReward.from_pretrained("NagaSaiAbhinay/CycleReward-Combo")
         case _:
             raise ValueError(f"model {name} not found")
         
@@ -86,6 +89,7 @@ if __name__ == "__main__":
         "PickScorer",
         "CLIPScore",
         "ImageReward",
+        "CycleReward",
     ]
 
     for name in names:


### PR DESCRIPTION
Hi `RE-N-Y`,

Opening a PR to merge CycleReward into imscore. The following things are pending:

- [ ] Move checkpoints to RE-N-Y/CycleReward etc... for all three variants
- [ ] Compute MAE w.r.t original model. 
- [ ] Add docs in README
- [ ] Unsure if importing the BLIP model from imscore.imreward is fine. As this makes cyclereward the only model in the repo with non-standalone files.

The inconsistency comes from the preprocessing difference:
        1. The original codebase resizes first and later applies normalization to [0, 1]
        2. `imscore` first normalizes to [0,1] and then resizes the image.

Let me know if you're okay with merging this and changes if so.

Usage:

```bash
pip install git+https://github.com/Abhinay1997/imscore@cyclereward
```

```python
from imscore.cyclereward.model import CycleReward
available_models = ["NagaSaiAbhinay/CycleReward-Combo" "NagaSaiAbhinay/CycleReward-T2I", "NagaSaiAbhinay/CycleReward-I2T"]
model_id = available_models[0]
model = CycleReward.from_pretrained(model_id)

prompts = "a photo of a cat"
pixels = Image.open("cat.jpg")
pixels = np.array(pixels)
pixels = rearrange(torch.tensor(pixels), "h w c -> 1 c h w") / 255.0

# prompts and pixels should have the same batch dimension
# pixels should be in the range [0, 1]
# score == logits
score = model.score(pixels, prompts) # full differentiable reward)
```